### PR TITLE
Add support for running under a custom folder or site

### DIFF
--- a/.env
+++ b/.env
@@ -10,3 +10,8 @@ HTTP_DOCKER_PORT='' # Container port
 # Application configuration
 GITHUB_REPOSITORY_URL=''
 GITHUB_SHA=''
+
+# Build configuration
+ASTRO_SITE_URL=''
+ASTRO_BASE_PATH=''
+ASTRO_ASSETS_PREFIX=''

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,6 +34,7 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
+    environment: github-pages
     timeout-minutes: 15
 
     steps:
@@ -49,6 +50,9 @@ jobs:
         env:
           GITHUB_REPOSITORY_URL: https://github.com/${{ github.repository }}
           GITHUB_SHA: ${{ github.sha }}
+          ASTRO_SITE_URL: ${{ vars.ASTRO_SITE_URL }}
+          ASTRO_BASE_PATH: ${{ vars.ASTRO_BASE_PATH }}
+          ASTRO_ASSETS_PREFIX: ${{ vars.ASTRO_ASSETS_PREFIX }}
           BUILD_CHECK: "false" # Skip type checks
         run: |
           # docker compose build

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -84,6 +84,9 @@ ENV GITHUB_SHA=${GITHUB_SHA}
 
 # Build application
 ARG BUILD_CHECK=true
+ARG ASTRO_SITE_URL
+ARG ASTRO_BASE_PATH
+ARG ASTRO_ASSETS_PREFIX
 RUN if [ "${BUILD_CHECK}" = "true" ]; then \
 		npm run build; \
 	else \

--- a/app/app/astro.config.mjs
+++ b/app/app/astro.config.mjs
@@ -7,6 +7,11 @@ import { i18n } from '/src/config'
 
 // https://astro.build/config
 export default defineConfig({
+	site: process.env.ASTRO_SITE_URL || undefined,
+	base: process.env.ASTRO_BASE_PATH || undefined,
+	build: {
+		assetsPrefix: process.env.ASTRO_ASSETS_PREFIX || undefined,
+	},
 	vite: {
 		optimizeDeps: {
 			esbuildOptions: {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,9 @@ x-common:
     environment: &app_environment
       GITHUB_REPOSITORY_URL: ${GITHUB_REPOSITORY_URL:-}
       GITHUB_SHA: ${GITHUB_SHA:-}
+      ASTRO_SITE_URL: ${ASTRO_SITE_URL:-}
+      ASTRO_BASE_PATH: ${ASTRO_BASE_PATH:-}
+      ASTRO_ASSETS_PREFIX: ${ASTRO_ASSETS_PREFIX:-}
 
 services:
 


### PR DESCRIPTION
There are now three new build configurations:

* `ASTRO_SITE_URL` - https://docs.astro.build/en/reference/configuration-reference/#site
* `ASTRO_BASE_PATH` - https://docs.astro.build/en/reference/configuration-reference/#base
* `ASTRO_ASSETS_PREFIX` - https://docs.astro.build/en/reference/configuration-reference/#buildassetsprefix

For example, if the plan is to build the site for `https://example.github.io/eml-reader` in a local fork, then the following variables should be added to the `github-pages` environment in the Github settings:

```
ASTRO_SITE_URL: https://example.github.io/eml-reader
ASTRO_ASSETS_PREFIX: /eml-reader/
```